### PR TITLE
Improve next path after user completes resource

### DIFF
--- a/app/controllers/resource_completion_controller.rb
+++ b/app/controllers/resource_completion_controller.rb
@@ -22,8 +22,16 @@ class ResourceCompletionController < ApplicationController
   private
     def next_path(resource)
       course = resource.course
-      if current_user.finished?(course)
-        course.next || course
+      if current_user.finished?(course) && resource.last?
+        next_course = course.next 
+        if next_course
+          if current_user.progress(next_course) == 0
+            flash[:notice] = "<strong>¡Felicitaciones!</strong> Has terminado #{course.name}. Esta aventura continúa con #{next_course.name}"
+          end
+          course.next
+        else
+          course
+        end
       else
         next_resource = resource.next
         next_resource ? [course, next_resource] : course

--- a/spec/features/resource_completition_spec.rb
+++ b/spec/features/resource_completition_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Resource completion", type: :feature do
     end
   end
 
-  context "when a user completes course and there are more courses" do
+  context "when user completes last resource (and course) and there are more courses" do
     scenario "should be redirected to next course" do
       resource = create(:resource)
       next_course = create(:course, row_position: :last)
@@ -44,7 +44,7 @@ RSpec.feature "Resource completion", type: :feature do
     end
   end
 
-  context "when a user completes course and there are no more courses" do
+  context "when user completes last resource (and course) and there are no more courses" do
     scenario "should be redirected to same course" do
       resource = create(:resource)
 
@@ -53,6 +53,21 @@ RSpec.feature "Resource completion", type: :feature do
       visit course_resource_path(resource.course, resource)
       click_link 'Completar y Continuar'
       expect(current_path).to eq course_path(resource.course)     
+    end
+  end
+
+  context "when user completes a course but it's not the last resource" do
+    scenario "should be redirected to next resource" do
+      course = create(:course)
+      resource = create(:resource, course: course)
+      next_resource = create(:resource, course: course, row_position: :last)
+      user.resources << next_resource # user has already completed next resource
+
+      login(user)
+
+      visit course_resource_path(course, resource)
+      click_link 'Completar y Continuar'
+      expect(current_path).to eq course_resource_path(course, next_resource)
     end
   end
 end


### PR DESCRIPTION
- If the user completes the course, but this is not the last resource, show next resource.
- Show a congratulations message after the user completes a course.
