### PR TITLE
Fix JS preview in challenges

### DIFF
--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -1,5 +1,6 @@
 class SolutionsController < ApplicationController
   before_action :private_access, except: [:preview] # we need the preview action to be public for evaluation
+  skip_before_action :verify_authenticity_token, only: [:preview]
 
   def create
     @challenge = Challenge.friendly.find(params[:challenge_id])


### PR DESCRIPTION
@simon0191 Me estaba sacando un error de forgery cuando incluía un archivo JS en el preview de algún reto. Esto lo soluciona. Corrí las pruebas y todo bien.

El error que salía era:

``` sh
ActionController::InvalidCrossOriginRequest (Security warning: an embedded <script> tag on another site requested protected JavaScript. If you know what you're doing, go ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.):
  actionpack (4.2.0) lib/action_controller/metal/request_forgery_protection.rb:225:in `verify_same_origin_request'
```
