### PR TITLE
Adjusted content-wrapper top padding

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,7 +61,7 @@ html.turbolinks-progress-bar::before {
 
 .content-wrapper {
   margin-top: -90px;
-  padding-top: 90px;
+  padding-top: 120px;
   &.no-scroll {
     overflow: hidden;
   }


### PR DESCRIPTION
Se ajustó el padding del content-wrapper para que no se viera muy pegado al header y además para que no se corten las alertas y notificaciones.
