### PR TITLE
Fix challenge evaluation

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -35,7 +35,7 @@ class Challenge < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name
 
-  enum evaluation_strategy: [:ruby_embedded, :phantomjs_embedded, :async_phantomjs_embedded, :ruby_git, :rails_git, :sinatra_git, :ruby_git_pr]
+  enum evaluation_strategy: [:ruby_embedded, :phantomjs_embedded, :ruby_git, :rails_git, :sinatra_git, :ruby_git_pr, :async_phantomjs_embedded]
 
   belongs_to :course
   has_many :documents, as: :folder


### PR DESCRIPTION
New `enum` options should be always placed at the end or, otherwise, it will change the order of the options in the database.