### PR TITLE
Corrección a barra lateral de entradas en el dashboard

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -70,7 +70,8 @@
 
 .feed {
   padding: 0;
-
+  max-height: 950px;
+  overflow: scroll;
   .entry {
     padding: 15px 20px;
     border-bottom: 1px solid #ccc;

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -15,7 +15,7 @@ class DashboardController < ApplicationController
     @finished_projects = Project.where(id: current_user.project_solutions.created_at_after(bow).pluck(:project_id)).count
     @received_badges = Badge.where(id: current_user.badge_ownerships.created_at_after(bow).pluck(:badge_id)).count
 
-    @notifications = Notification.limit(50)
+    @notifications = Notification.limit(25)
   end
 
   private


### PR DESCRIPTION
Hola MakeIt,

Como se mencionó en el grupo de slack, la barra lateral de entradas que se implementó recientemente en el dashboard está demasiado larga, por lo que decidí modificar ligeramente la regla css para el contenedor de las entradas con el propósito de hacerlo scrollable.

Por otra parte, a pesar de que UI del dashboard mejoró como consecuencia de la anterior implementación, el contenedor scrollable seguía muy extenso, por lo que decidí limitar aún más las notificaciones que se retornaban desde el controlador, pasando de 50 a 25, quedando ahora mucho más razonable según mi criterio.
