### PR TITLE
Fix resources ordering

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -26,7 +26,7 @@
 
 class Resource < ActiveRecord::Base
   include RankedModel
-  ranks :row, with_same: :subject_id
+  ranks :row, with_same: :subject_id, class_name: 'Resource'
 
   extend FriendlyId
   friendly_id :title


### PR DESCRIPTION
When we switched resources to STI, we introduced a bug in the ordering (ranked model). This commit fixes it.