### PR TITLE
Fix url de inicio en el breadcrumb

### DIFF
--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,5 @@
 crumb :root do
-  link "Inicio", root_path
+  link "Inicio", dashboard_path
 end
 
 crumb :subjects do


### PR DESCRIPTION
Se corrige la URL que utiliza el breadcrumb para el link de inicio, antes redireccionaba
al root_path ahora redirecciona a dashboard_path.

Fix #619.