### PR TITLE
Fix profile page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -66,6 +66,7 @@ class UsersController < ApplicationController
   # /u/:nickname
   def profile
     @user = User.find_by_nickname!(params[:nickname])
+    @paths = @user.paths
     owner_or_admin_access(@user,@user) unless @user.has_public_profile?
     @is_own_profile = (@user == current_user)
   end

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -72,29 +72,32 @@
           <% end %>
         </div>
 
-        <% Subject.published.all.each_with_index do |subject, i| %>
-          <% progress = @user.stats.progress_by_subject(subject)%>
-          <% if i % 2 == 0 %><div class="clearfix visible-xs"></div><% end %>
-          <% if i % 3 == 0 %><div class="clearfix visible-sm"></div><% end %>
-          <% if i % 4 == 0 %><div class="clearfix visible-md visible-lg"></div><% end %>
-          <div class="col-xs-6 col-sm-4 col-md-3">
-            <div class="course-status">
-              <span class="course-name"><%= subject.name %></span>
-              <div class="progress">
-                <%= progress_bar(progress: progress, show_percentage: true) %>
-              </div>
-              <% if @is_own_profile %>
-                <% if progress == 0 %>
-                  <%= link_to "iniciar", subject_path(subject) %>
-                <% elsif progress == 1 %>
-                  <p class="text-muted">finalizado</p>
-                <% else %>
-                  <%= link_to "continuar", subject_path(subject) %>
+        <% @paths.first.phases.order(:row).each do |phase| %>
+          <% phase.subjects.order(:row).each_with_index do |subject, i| %>
+            <% progress = @user.stats.progress_by_subject(subject)%>
+            <% if i % 2 == 0 %><div class="clearfix visible-xs"></div><% end %>
+            <% if i % 3 == 0 %><div class="clearfix visible-sm"></div><% end %>
+            <% if i % 4 == 0 %><div class="clearfix visible-md visible-lg"></div><% end %>
+            <div class="col-xs-6 col-sm-4 col-md-3">
+              <div class="course-status">
+                <span class="course-name"><%= subject.name %></span>
+                <div class="progress">
+                  <%= progress_bar(progress: progress, show_percentage: true) %>
+                </div>
+                <% if @is_own_profile %>
+                  <% if progress == 0 %>
+                    <%= link_to "iniciar", subject_path(subject) %>
+                  <% elsif progress == 1 %>
+                    <p class="text-muted">finalizado</p>
+                  <% else %>
+                    <%= link_to "continuar", subject_path(subject) %>
+                  <% end %>
                 <% end %>
-              <% end %>
+              </div>
             </div>
-          </div>
+          <% end %>
         <% end %>
+
       </div><!-- /row -->
     </div><!-- /profile-progress -->
 


### PR DESCRIPTION
Fixed subject progress in profile page to show only the user's subjects from his paths.

Note: Showing only the subjects of the first path for the moment.