### PR TITLE
Don't skip auth token in developer guide

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
   before_action :save_referer, except: [:handbook]
-  skip_before_action :verify_authenticity_token, only: [:send_web_developer_guide]
 
   def home
   end


### PR DESCRIPTION
For some reason I skipped the auth token in the commit fae1088, but we are receiving spam because of that.