### PR TITLE
Adding new logic for next challenge

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -150,6 +150,6 @@ class Challenge < ApplicationRecord
     end
 
     def find_next_challenge
-      subject.challenges.order(:row).where("row > ?", self.row).take
+      subject.challenges.order(:row).where("row > ? AND published = ?", self.row, true).take
     end
 end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -121,6 +121,16 @@ class Challenge < ApplicationRecord
     "el reto #{to_html_link} del tema #{subject.to_html_link}"
   end
 
+  def next_challenge
+    return nil if is_last_challenge?
+
+    find_next_challenge
+  end
+
+  def is_last_challenge?
+    self == subject.last_challenge
+  end
+
   private
     def default_values
       self.published ||= false
@@ -137,5 +147,9 @@ class Challenge < ApplicationRecord
         errors[:base] << "Cannot delete Challenge because this have solutions associated"
         return false
       end
+    end
+
+    def find_next_challenge
+      subject.challenges.order(:row).where("row > ?", self.row).take
     end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -70,6 +70,10 @@ class Subject < ApplicationRecord
     "<a href='#{to_path}'>#{to_s}</a>"
   end
 
+  def last_challenge
+    challenges.order(:row).last
+  end
+
   private
     def default_values
       self.published ||= false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -215,11 +215,11 @@ class User < ApplicationRecord
 
   def next_challenge
     if last_solution.nil? # user has not completed nor attempted any challenge
-      Challenge.for(self).order_by_subject_and_rank.first
-    elsif last_solution.completed? # user's last action was a challenge completion
+      Challenge.for(self).where(published: true).order_by_subject_and_rank.first
+    elsif last_pending_challenge.present? # user has a pending challenge
+      last_pending_challenge
+    else # user attempted a challenge but it was not completed or no attempted challenges
       find_next_challenge
-    else # user attempted a challenge but it was not completed
-      last_solution.challenge
     end
   end
 
@@ -302,7 +302,7 @@ class User < ApplicationRecord
     # returns the next published challenge after the one of the argument in the
     # same subject or nil if it's the last one
     def next_challenge_in_subject_after(challenge)
-      challenge.subject.challenges.for(self).order(:row).where("row > ?", challenge.row).take
+      challenge.subject.challenges.for(self).order(:row).where("row > ? AND published = ?", challenge.row, true).take
     end
 
     def first_challenge_of_next_subject(current_subject)

--- a/app/views/challenges/discussion.html.erb
+++ b/app/views/challenges/discussion.html.erb
@@ -3,7 +3,7 @@
 <div class="container-fluid challenge-discussion default-top-padding">
   <div class="discussion-actions text-right hidden-md hidden-lg">
     <%= link_to "Siguiente reto <span class='glyphicon glyphicon-chevron-right'></span>".html_safe,
-        [@challenge.subject, current_user.next_challenge], class: "btn btn-primary" %>
+        [@challenge.subject, @challenge.next_challenge], class: "btn btn-primary" %>
   </div>
   <div class="row">
     <div class="col-md-6">
@@ -28,7 +28,7 @@
     <div class="col-md-6">
       <div class="discussion-actions text-right hidden-xs hidden-sm">
         <%= link_to "Siguiente reto <span class='glyphicon glyphicon-chevron-right'></span>".html_safe,
-            [@challenge.subject, current_user.next_challenge], class: "btn btn-primary" %>
+            [@challenge.subject, @challenge.next_challenge], class: "btn btn-primary" %>
       </div>
       <div>
         <%= render "comments/embedded", commentable: @challenge, questions: [


### PR DESCRIPTION
Se agrega una nueva logica para seleccionar el proximo reto en las vistas de la discucion y para el dashboard se asegura que no vaya a mostrar retos sin publicar.

Fix #913