### PR TITLE
Update ConvertLoop event_log name for leads interacpedia/mintic landing

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -156,7 +156,7 @@ class PagesController < ApplicationController
     data = {
       pid: cookies[:dp_pid],
       program: "Intro to Java Script Interacpedia MinTic",
-      event: "filled-intro-to-js-form",
+      event: "filled-intro-to-js-form-interacpedia-mintic",
       first_name: params['first-name'],
       last_name: params['last-name'],
       email: params['email'],

--- a/app/jobs/create_lead_job.rb
+++ b/app/jobs/create_lead_job.rb
@@ -9,7 +9,6 @@ class CreateLeadJob < ActiveJob::Base
     country = data[:country]
     mobile = data[:mobile]
     source = data[:source]
-    program = data[:program]
 
     person = { pid: pid, email: email, first_name: first_name, last_name: last_name,
         country_code: country, mobile: mobile, source: source }


### PR DESCRIPTION
The name of the ConvertLoop event log has been updated  from `filled-intro-to-js-form` to `filled-intro-to-js-form-interacpedia-mintic` 
The reason is that we should not associate a segment to the automatic email in ConvertLoop becuase one lead can signup to the free course more than once, so we need to associate the automatic email to one specific event. 