### PR TITLE
Remove mintic word from interacpedia landing path

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -152,6 +152,10 @@ class PagesController < ApplicationController
     redirect_to "/thanks-intro-to-js"
   end
 
+  def redirect_to_js_interacpedia
+    redirect_to "/introduccion-a-javascript-interacpedia"
+  end
+
   def create_intro_to_js_lead_interacpedia_mintic
     data = {
       pid: cookies[:dp_pid],
@@ -165,7 +169,7 @@ class PagesController < ApplicationController
       ip: request.remote_ip
     }
     CreateLeadJob.perform_later(data)
-    redirect_to "/thanks-intro-to-js-mintic"
+    redirect_to "/thanks-intro-to-js-interacpedia"
   end
 
   def create_intro_to_python_lead

--- a/app/views/pages/intro_to_js_interacpedia_mintic.html.erb
+++ b/app/views/pages/intro_to_js_interacpedia_mintic.html.erb
@@ -112,6 +112,6 @@
 
   <%= render "footer" %>
 
-  <%= render "program_registration_free_course", action: "/introduccion-a-javascript-mintic" %>
+  <%= render "program_registration_free_course", action: "/introduccion-a-javascript-interacpedia" %>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,9 @@ Rails.application.routes.draw do
   get "full_stack_web_developer", to: redirect('/full-stack-online')
   get "curso-javascript-basico", to: redirect(ENV['javascript-course-url'] || "https://www.youtube.com/c/MakeitrealCamp1/live")
   get "introduccion-a-javascript", to: "pages#intro_to_js", as: :intro_to_js
-  get "introduccion-a-javascript-mintic", to: "pages#intro_to_js_interacpedia_mintic", as: :intro_to_js_interacpedia_mintic
-  post "introduccion-a-javascript-mintic", to: "pages#create_intro_to_js_lead_interacpedia_mintic"
+  get "introduccion-a-javascript-interacpedia", to: "pages#intro_to_js_interacpedia_mintic", as: :intro_to_js_interacpedia_mintic
+  get "introduccion-a-javascript-mintic", to: "pages#redirect_to_js_interacpedia"
+  post "introduccion-a-javascript-interacpedia", to: "pages#create_intro_to_js_lead_interacpedia_mintic"
   post "introduccion-a-javascript", to: "pages#create_intro_to_js_lead"
   get "introduccion-a-python-para-data-science", to: "pages#intro_to_python"
   post "introduccion-a-python-para-data-science", to: "pages#create_intro_to_python_lead"
@@ -35,7 +36,7 @@ Rails.application.routes.draw do
   get "thanks-top", to: "pages#thanks_top"
   get "thanks-data-science-online", to: "pages#thanks_online"
   get "thanks-intro-to-js", to:"pages#thanks_online_innpulsa"
-  get "thanks-intro-to-js-mintic", to:"pages#thanks_online_interacpedia_mintic"
+  get "thanks-intro-to-js-interacpedia", to:"pages#thanks_online_interacpedia_mintic"
   get "thanks-intro-to-python", to:"pages#thanks_online_innpulsa"
   get "thanks-fs-becas-mujeres", to:"pages#thanks_online"
 


### PR DESCRIPTION
We had to update the path . Ineracpedia required to remove mintic word from the url. 